### PR TITLE
Don't modify mc-data to get the latest version

### DIFF
--- a/src/disk/WorldProvider.ts
+++ b/src/disk/WorldProvider.ts
@@ -6,7 +6,7 @@ import { KeyBuilder, Version, KeyData, recurseMinecraftKeys } from './databaseKe
 import MinecraftData from 'minecraft-data'
 import { IChunkColumn, StorageType } from '../chunk/Chunk'
 
-const latestVersion = <any>MinecraftData.versions.bedrock.pop()
+const latestVersion = <any>MinecraftData.versions.bedrock[MinecraftData.versions.bedrock.length - 1]
 
 export class WorldProvider {
   db: LevelDB


### PR DESCRIPTION
Breaks compatibility with the latest version by removing it from the supported version array.